### PR TITLE
Add RuntimeDirectory to aptly-spooler.service

### DIFF
--- a/pkgbot/config/aptly-spooler.service
+++ b/pkgbot/config/aptly-spooler.service
@@ -6,6 +6,8 @@ After=network.target
 Type=simple
 User=mirror
 Group=mirror
+RuntimeDirectory=aptly-spooler
+RuntimeDirectoryMode=0750
 ExecStart=/usr/local/bin/aptly-spooler --socket=/var/run/aptly-spooler/fifo.sock --save-file=/var/run/aptly-spooler/jobs
 
 [Install]


### PR DESCRIPTION
Fix issues with startup of aptly-spooler after a reboot by adding RuntimeDirectory to `aptly-spooler.service`.